### PR TITLE
Allow read_absmap to handle uppercase names

### DIFF
--- a/R/read_absmaps.R
+++ b/R/read_absmaps.R
@@ -44,6 +44,7 @@ read_absmap <- function(name = NULL,
 
   # Define name
   if (is.null(name)) name <- paste0(area, year)
+  name <- stringr::str_to_lower(name)
 
   # Define url
   base_url <- "https://github.com/wfmackey/absmapsdata/raw/master/data/"

--- a/tests/testthat/test-read_absmaps.R
+++ b/tests/testthat/test-read_absmaps.R
@@ -1,6 +1,7 @@
 test_that("read_absmaps() works", {
 
   expect_type(read_absmap("sa42016"), "list")
+  expect_type(read_absmap("SA42016"), "list")
 
   expect_identical(names(read_absmap("state2021")),
                    c("state_code_2021",
@@ -9,6 +10,12 @@ test_that("read_absmaps() works", {
                      "cent_lat",
                      "cent_long",
                      "geometry"))
+
+  expect_identical(names(read_absmap("SA32016")),
+                   c("sa3_code_2016", "sa3_name_2016", "sa4_code_2016",
+                     "sa4_name_2016", "gcc_code_2016", "gcc_name_2016",
+                     "state_code_2016", "state_name_2016", "areasqkm_2016", "cent_long",
+                     "cent_lat", "geometry"))
 
   # errors
   expect_error(read_absmap(), regexp = "Please")


### PR DESCRIPTION
Firstly, thanks for building this function in to the package.

Just thought it might be useful to allow the read_absmap function to handle uppercase names.