### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,5 +93,5 @@ contained in [`absmapsdata`](https://github.com/wfmackey/absmapsdata).
 See `?strayr::read_absmaps`.
 
 ``` r
-read_absmaps("sa42021")
+read_absmap("sa42021")
 ```


### PR DESCRIPTION
This is a really minor update but README file says `read_absmaps` but the actual function is `read_absmap` without the "s" at the end.